### PR TITLE
Fix NcNameResolver.fixNcName (don't remove first character if valid)

### DIFF
--- a/52n-oxf-third-party/oxf-third-party-ncname-resolver/src/main/java/org/n52/oxf/xml/NcNameResolver.java
+++ b/52n-oxf-third-party/oxf-third-party-ncname-resolver/src/main/java/org/n52/oxf/xml/NcNameResolver.java
@@ -445,9 +445,12 @@ public class NcNameResolver {
 
         // Check first character
         char c = nonNcName.charAt(0);
-        if ( ! (c == '_' && NcNameResolver.isLetter(c))) {
+        if (c == '_' || NcNameResolver.isLetter(c)) {
+            sb.append(c);
+        } else {
             sb.append('_');
         }
+
         // Check the rest of the characters
         for (int i = 1; i < nonNcName.length(); i++) {
             char currentChar = nonNcName.charAt(i);

--- a/52n-oxf-third-party/oxf-third-party-ncname-resolver/src/test/java/org/n52/oxf/xml/NcNameResolverTest.java
+++ b/52n-oxf-third-party/oxf-third-party-ncname-resolver/src/test/java/org/n52/oxf/xml/NcNameResolverTest.java
@@ -1,0 +1,43 @@
+/**
+ * ﻿Copyright (C) 2012-2014 52°North Initiative for Geospatial Open Source
+ * Software GmbH
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License version 2 as publishedby the Free
+ * Software Foundation.
+ *
+ * If the program is linked with libraries which are licensed under one of the
+ * following licenses, the combination of the program with the linked library is
+ * not considered a "derivative work" of the program:
+ *
+ *     - Apache License, version 2.0
+ *     - Apache Software License, version 1.0
+ *     - GNU Lesser General Public License, version 3
+ *     - Mozilla Public License, versions 1.0, 1.1 and 2.0
+ *     - Common Development and Distribution License (CDDL), version 1.0
+ *
+ * Therefore the distribution of the program linked with libraries licensed under
+ * the aforementioned licenses, is permitted by the copyright holders if the
+ * distribution is compliant with both the GNU General Public License version 2
+ * and the aforementioned licenses.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ */
+package org.n52.oxf.xml;
+
+import static org.junit.Assert.*;
+
+import org.junit.Test;
+
+public class NcNameResolverTest {
+    @Test
+    public void testFixNcName() {
+        String noFixString = "this_one_needs_no_fixing";
+        String needsFixString = "1string&_needs_fixing";
+        String fixedString = "_string__needs_fixing";
+        assertEquals(noFixString, NcNameResolver.fixNcName(noFixString));
+        assertEquals(fixedString, NcNameResolver.fixNcName(needsFixString));
+    }
+}


### PR DESCRIPTION
NcNameResolver.fixNcName was removing the first character of an NcName if it was valid. Fix and add test case.
