### PR TITLE
Fix NPE in InsertionMetadataMissingCase

### DIFF
--- a/52n-oxf-xmlbeans/src/main/java/org/n52/oxf/xmlbeans/parser/InsertionMetadataMissingCase.java
+++ b/52n-oxf-xmlbeans/src/main/java/org/n52/oxf/xmlbeans/parser/InsertionMetadataMissingCase.java
@@ -70,6 +70,8 @@ public class InsertionMetadataMissingCase extends AbstractDependentLaxValidation
 	{
 		return xve != null &&
 				xve.getOffendingQName() == null &&
+				xve.getFieldQName() != null &&
+				xve.getExpectedQNames() != null &&
 				xve.getFieldQName().equals(XMLConstants.QN_SWES_2_0_METADATA) &&
 				xve.getExpectedQNames().contains(XMLConstants.QN_SWES_2_0_INSERTION_METADATA);
 	}


### PR DESCRIPTION
On some rare occasion the lax validation case threw a NPE, because `xve.getFieldQName()` returned `null`.
